### PR TITLE
Upgrade to latest scalariform with scala_2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 sudo: false

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ repositories { jcenter() }
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile "org.scala-lang:scala-library:2.11.8"
-  compile "org.scalariform:scalariform_2.11:0.1.8"
+  compile "org.scala-lang:scala-library:2.12.1"
+  compile "com.github.machaval:scalariform_2.12:0.2.0"
   testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
     exclude group: 'org.codehaus.groovy', module: 'groovy-all'
   }

--- a/src/test/groovy/nl/javadude/gradle/plugins/scalariform/ScalariformPluginSpec.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/scalariform/ScalariformPluginSpec.groovy
@@ -56,7 +56,7 @@ apply plugin: "scala"
     def result = runTasksSuccessfully("formatTestScala")
 
     then:
-    testFile.text == "import scala.collection.mutable.{Map, ListBuffer}"
+    testFile.text == "import scala.collection.mutable.{ Map, ListBuffer }"
   }
 
   def "should execute all individual tasks when calling formatAll"() {

--- a/src/test/groovy/nl/javadude/gradle/plugins/scalariform/tasks/ScalariformSpec.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/scalariform/tasks/ScalariformSpec.groovy
@@ -44,7 +44,7 @@ class ScalariformSpec extends ProjectSpec {
     scalariformTask.execute()
 
     then:
-    file.text == "import scala.collection.mutable.{Map, ListBuffer}"
+    file.text == "import scala.collection.mutable.{ Map, ListBuffer }"
   }
 
   def "should align parameters"() {
@@ -62,8 +62,7 @@ case class Foo(name: String,
     file.text == """
 case class Foo(
   name: String,
-  bar:  Int
-)"""
+  bar:  Int)"""
   }
 
   def "should align single line case statements"() {
@@ -108,8 +107,7 @@ class Person(
     file.text == """
 class Person(
     name: String,
-    age: Int
-) {
+    age: Int) {
   def method = ???
 }"""
   }


### PR DESCRIPTION
I've releases scalariform 0.2.0  under a different orgId as it looks like the project is dead. The feature I need is that now it depends on scala_2.12. This pull request updates the build to the latest version. Can you please release a new version of the plugin with this.